### PR TITLE
Android branding work only

### DIFF
--- a/app/constants/colors.js
+++ b/app/constants/colors.js
@@ -1,25 +1,71 @@
-import { isIOS } from '../utils/deviceInfo';
+import * as theme from './colorsRocketChat';
 
-export const COLOR_DANGER = '#f5455c';
-export const COLOR_SUCCESS = '#2de0a5';
-export const COLOR_PRIMARY = '#1d74f5';
-export const COLOR_WHITE = '#fff';
-export const COLOR_BUTTON_PRIMARY = COLOR_PRIMARY;
-export const COLOR_TITLE = '#0C0D0F';
-export const COLOR_TEXT = '#2F343D';
-export const COLOR_TEXT_DESCRIPTION = '#9ca2a8';
-export const COLOR_SEPARATOR = '#A7A7AA';
-export const COLOR_BACKGROUND_CONTAINER = '#f3f4f5';
-export const COLOR_BORDER = '#e1e5e8';
-export const COLOR_UNREAD = '#e1e5e8';
-export const COLOR_TOAST = '#0C0D0F';
-export const STATUS_COLORS = {
-	online: '#2de0a5',
-	busy: COLOR_DANGER,
-	away: '#ffd21f',
-	offline: '#cbced1'
-};
+//Important colors and colors for status symbols(i.e online /offline)
+export const COLOR_WHITE = theme.COLOR_WHITE;
+export const COLOR_PRIMARY = theme.COLOR_PRIMARY;
+export const COLOR_DANGER = theme.COLOR_DANGER;
+export const COLOR_SUCCESS = theme.COLOR_SUCCESS;
+export const STATUS_COLORS = theme.STATUS_COLORS;
 
-export const HEADER_BACKGROUND = isIOS ? '#f8f8f8' : '#2F343D';
-export const HEADER_TITLE = isIOS ? COLOR_TITLE : COLOR_WHITE;
-export const HEADER_BACK = isIOS ? COLOR_PRIMARY : COLOR_WHITE;
+//colors relating to most text and titles
+export const COLOR_TITLE = theme.COLOR_TITLE;
+export const COLOR_TITLE_HEADER_BUTTON = theme.COLOR_TITLE_HEADER_BUTTON;
+export const COLOR_TEXT = theme.COLOR_TEXT;
+export const COLOR_TEXT_DESCRIPTION = theme.COLOR_TEXT_DESCRIPTION;
+export const COLOR_UNREAD = theme.COLOR_UNREAD;
+
+//Colors relating to buttons, backgrounds and borders
+export const COLOR_BACKGROUND_CONTAINER = theme.COLOR_BACKGROUND_CONTAINER;
+export const COLOR_BACKGROUND_LIST = theme.COLOR_BACKGROUND_LIST;
+export const COLOR_BACKGROUND_CONTAINER_PRIMARY = theme.COLOR_BACKGROUND_CONTAINER_PRIMARY;
+export const LOADING_SCREEN_BACKGROUND = theme.LOADING_SCREEN_BACKGROUND;
+export const COLOR_BUTTON_PRIMARY = theme.COLOR_BUTTON_PRIMARY;
+export const COLOR_BUTTON_SECONDARY = theme.COLOR_BUTTON_SECONDARY;
+export const COLOR_SEPARATOR = theme.COLOR_SEPARATOR;
+export const COLOR_BORDER = theme.COLOR_BORDER;
+export const COLOR_BORDER_SECONDARY = theme.COLOR_BORDER_SECONDARY;
+export const COLOR_TOAST = theme.COLOR_TOAST;
+export const COLOR_LOADING = theme.COLOR_LOADING;
+
+//Colors related to header/ status bar
+export const HEADER_BACKGROUND = theme.HEADER_BACKGROUND;
+export const HEADER_TITLE = theme.HEADER_TITLE;
+export const HEADER_BACK = theme.HEADER_BACK;
+export const HEADER_GRADIENT = theme.HEADER_GRADIENT;
+
+//Colors related to drop down sort tab for roomslist
+export const COLOR_DROPDOWN_CONTAINER_HEADER = theme.COLOR_DROPDOWN_CONTAINER_HEADER; //sort bar for chat channels
+export const COLOR_BUTTON_DISABLED = theme.COLOR_BUTTON_DISABLED;
+export const COLOR_ROOMS_ACTION_BUTTON = theme.COLOR_ROOMS_ACTION_BUTTON;
+export const COLOR_GROUP_TITLE_CONTAINER = theme.COLOR_GROUP_TITLE_CONTAINER;
+export const COLOR_GROUP_TITLE = theme.COLOR_GROUP_TITLE;
+export const COLOR_GROUP_SORT_ICON = theme.COLOR_GROUP_SORT_ICON;
+export const COLOR_GROUP_SORT_ICON_HEADER = theme.COLOR_GROUP_SORT_ICON_HEADER;
+export const COLOR_SAFE_AREA_BACKGROUND = theme.COLOR_SAFE_AREA_BACKGROUND;
+export const COLOR_SEARCHBOX_CONTAINER = theme.COLOR_SEARCHBOX_CONTAINER;
+export const COLOR_SEARCHBOX_BACKGROUND = theme.COLOR_SEARCHBOX_BACKGROUND;
+export const COLOR_SEARCHBOX_TEXT = theme.COLOR_SEARCHBOX_TEXT;
+export const COLOR_TEXT_INPUT_BACKGROUND = theme.COLOR_TEXT_INPUT_BACKGROUND;
+export const COLOR_TEXT_HEADER = theme.COLOR_TEXT_HEADER;
+export const COLOR_TEXT_DROPDOWN_CONTAINER = theme.COLOR_TEXT_DROPDOWN_CONTAINER;
+export const COLOR_ITEM_CURRENT = theme.COLOR_ITEM_CURRENT;
+
+//Colors related to linked users / items in chat
+export const COLOR_MENTIONED_USER = theme.COLOR_MENTIONED_USER
+export const COLOR_BACKGROUND_MENTIONED_USER = theme.COLOR_BACKGROUND_MENTIONED_USER //transparent
+export const COLOR_MENTIONED_LOGGED_USER = theme.COLOR_MENTIONED_LOGGED_USER
+export const COLOR_BACKGROUND_MENTIONED_LOGGED_USER = theme.COLOR_BACKGROUND_MENTIONED_LOGGED_USER
+export const COLOR_MENTIONED_USER_ALL = theme.COLOR_MENTIONED_USER_ALL
+export const COLOR_BACKGROUND_MENTIONED_USER_ALL = theme.COLOR_BACKGROUND_MENTIONED_USER_ALL
+export const COLOR_LINK = theme.COLOR_LINK
+export const COLOR_REPLIED_THREAD = theme.COLOR_REPLIED_THREAD
+export const COLOR_MESSAGE_THREAD = theme.COLOR_MESSAGE_THREAD
+export const COLOR_MESSAGE_THREAD_TEXT = theme.COLOR_MESSAGE_THREAD_TEXT
+export const COLOR_LINK_TITLE = theme.COLOR_LINK_TITLE
+export const COLOR_REACTIONS = theme.COLOR_REACTIONS
+export const COLOR_REACTIONS_COUNT = theme.COLOR_REACTIONS_COUNT
+export const COLOR_KEYBOARD_ICONS = theme.COLOR_KEYBOARD_ICONS
+
+//colors in profile view
+export const COLOR_AVATAR_BUTTON = theme.COLOR_AVATAR_BUTTON;
+export const COLOR_DIALOG_INPUT = theme.COLOR_DIALOG_INPUT;

--- a/app/constants/colorsRocketChat.js
+++ b/app/constants/colorsRocketChat.js
@@ -1,0 +1,67 @@
+import { isIOS } from '../utils/deviceInfo';
+
+//Important colors and colors for status symbols(i.e online /offline)
+export const COLOR_WHITE = '#fff';
+export const COLOR_PRIMARY = '#1d74f5';
+export const COLOR_DANGER = '#f5455c';
+export const COLOR_SUCCESS = '#2de0a5';
+export const STATUS_COLORS = {
+	online: '#2de0a5',
+	busy: COLOR_DANGER,
+	away: '#ffd21f',
+	offline: '#cbced1'
+};
+
+
+//colors relating to most text and titles
+export const COLOR_TITLE = '#0C0D0F';
+export const COLOR_TEXT = '#2F343D';
+export const COLOR_TEXT_DESCRIPTION = '#9ca2a8';
+export const COLOR_UNREAD = '#e1e5e8';
+
+//Colors related to header/ status bar
+export const HEADER_BACKGROUND = isIOS ? '#f8f8f8' : '#2F343D';
+export const HEADER_TITLE = isIOS ? COLOR_TITLE : COLOR_WHITE;
+export const HEADER_BACK = isIOS ? COLOR_PRIMARY : COLOR_WHITE;
+export const HEADER_GRADIENT = null; // we don't use a header gradient here
+
+//Colors relating to buttons, backgrounds and borders
+export const COLOR_BACKGROUND_CONTAINER = '#f3f4f5';
+export const COLOR_BACKGROUND_LIST = COLOR_WHITE;
+export const COLOR_BACKGROUND_CONTAINER_PRIMARY = COLOR_WHITE;
+export const LOADING_SCREEN_BACKGROUND = COLOR_WHITE;
+export const COLOR_BUTTON_PRIMARY = COLOR_PRIMARY;
+export const COLOR_BUTTON_SECONDARY = '#414852';
+export const COLOR_SEPARATOR = '#A7A7AA';
+export const COLOR_BORDER = '#e1e5e8';
+export const COLOR_BORDER_SECONDARY = COLOR_WHITE;
+export const COLOR_TOAST = '#0C0D0F';
+
+//Colors related to drop down sort tab for roomslist
+export const COLOR_DROPDOWN_CONTAINER_HEADER = isIOS ? COLOR_WHITE : '#54585E';//sort bar for chat channels
+export const COLOR_BUTTON_DISABLED = 'rgba(65, 72, 82, 0.7)';
+export const COLOR_GROUP_TITLE_CONTAINER = isIOS ? COLOR_WHITE : '#9ea2a8';
+export const COLOR_GROUP_TITLE = isIOS ? COLOR_TEXT : '#54585E';
+export const COLOR_GROUP_SORT_ICON = COLOR_TEXT_DESCRIPTION;
+export const COLOR_SAFE_AREA_BACKGROUND = isIOS ? '#F7F8FA' : '#E1E5E8';
+export const COLOR_SEARCHBOX_CONTAINER = isIOS ? '#F7F8FA' : '#54585E';
+export const COLOR_SEARCHBOX_BACKGROUND = '#E1E5E8';
+export const COLOR_SEARCHBOX_TEXT = '#8E8E93';
+export const COLOR_TEXT_INPUT_BACKGROUND = COLOR_WHITE;
+export const COLOR_TEXT_HEADER = isIOS ? COLOR_TEXT_DESCRIPTION : COLOR_WHITE;
+
+//Colors related to linked users / items in chat
+export const COLOR_MENTIONED_USER = '#0072FE';
+export const COLOR_BACKGROUND_MENTIONED_USER = '#E8F2FF';
+export const COLOR_MENTIONED_LOGGED_USER = COLOR_WHITE;
+export const COLOR_BACKGROUND_MENTIONED_LOGGED_USER = COLOR_PRIMARY;
+export const COLOR_MENTIONED_USER_ALL = COLOR_WHITE;
+export const COLOR_BACKGROUND_MENTIONED_USER_ALL = '#FF5B5A';
+export const COLOR_LINK = COLOR_PRIMARY;
+export const COLOR_REPLIED_THREAD = COLOR_PRIMARY;
+export const COLOR_MESSAGE_THREAD = COLOR_PRIMARY;
+export const COLOR_MESSAGE_THREAD_TEXT = COLOR_WHITE;
+export const COLOR_LINK_TITLE = COLOR_PRIMARY;
+export const COLOR_REACTIONS = COLOR_PRIMARY;
+export const COLOR_REACTIONS_COUNT = COLOR_PRIMARY;
+export const COLOR_KEYBOARD_ICONS = COLOR_PRIMARY;

--- a/app/constants/colorsRocketChat.js
+++ b/app/constants/colorsRocketChat.js
@@ -15,6 +15,7 @@ export const STATUS_COLORS = {
 
 //colors relating to most text and titles
 export const COLOR_TITLE = '#0C0D0F';
+export const COLOR_TITLE_HEADER_BUTTON = isIOS ? COLOR_PRIMARY : COLOR_WHITE;
 export const COLOR_TEXT = '#2F343D';
 export const COLOR_TEXT_DESCRIPTION = '#9ca2a8';
 export const COLOR_UNREAD = '#e1e5e8';
@@ -36,19 +37,24 @@ export const COLOR_SEPARATOR = '#A7A7AA';
 export const COLOR_BORDER = '#e1e5e8';
 export const COLOR_BORDER_SECONDARY = COLOR_WHITE;
 export const COLOR_TOAST = '#0C0D0F';
+export const COLOR_LOADING = 'rgba(255,255,255,.2)';
 
 //Colors related to drop down sort tab for roomslist
 export const COLOR_DROPDOWN_CONTAINER_HEADER = isIOS ? COLOR_WHITE : '#54585E';//sort bar for chat channels
 export const COLOR_BUTTON_DISABLED = 'rgba(65, 72, 82, 0.7)';
+export const COLOR_ROOMS_ACTION_BUTTON = '#fc0abb';
 export const COLOR_GROUP_TITLE_CONTAINER = isIOS ? COLOR_WHITE : '#9ea2a8';
 export const COLOR_GROUP_TITLE = isIOS ? COLOR_TEXT : '#54585E';
 export const COLOR_GROUP_SORT_ICON = COLOR_TEXT_DESCRIPTION;
+export const COLOR_GROUP_SORT_ICON_HEADER = COLOR_TEXT_DESCRIPTION;
 export const COLOR_SAFE_AREA_BACKGROUND = isIOS ? '#F7F8FA' : '#E1E5E8';
 export const COLOR_SEARCHBOX_CONTAINER = isIOS ? '#F7F8FA' : '#54585E';
 export const COLOR_SEARCHBOX_BACKGROUND = '#E1E5E8';
 export const COLOR_SEARCHBOX_TEXT = '#8E8E93';
 export const COLOR_TEXT_INPUT_BACKGROUND = COLOR_WHITE;
 export const COLOR_TEXT_HEADER = isIOS ? COLOR_TEXT_DESCRIPTION : COLOR_WHITE;
+export const COLOR_TEXT_DROPDOWN_CONTAINER = COLOR_TEXT_DESCRIPTION;
+export const COLOR_ITEM_CURRENT = '#E1E5E8';
 
 //Colors related to linked users / items in chat
 export const COLOR_MENTIONED_USER = '#0072FE';
@@ -65,3 +71,7 @@ export const COLOR_LINK_TITLE = COLOR_PRIMARY;
 export const COLOR_REACTIONS = COLOR_PRIMARY;
 export const COLOR_REACTIONS_COUNT = COLOR_PRIMARY;
 export const COLOR_KEYBOARD_ICONS = COLOR_PRIMARY;
+
+//colors in profile view
+export const COLOR_AVATAR_BUTTON = '#e1e5e8';
+export const COLOR_DIALOG_INPUT = 'rgba(0,0,0,.15)';

--- a/app/constants/icons.js
+++ b/app/constants/icons.js
@@ -4,3 +4,4 @@ export const PRIVATE_GROUP_ICON = theme.PRIVATE_GROUP_ICON
 export const PUBLIC_GROUP_ICON = theme.PUBLIC_GROUP_ICON
 export const IS_LOADING_SCREEN_PNG = theme.IS_LOADING_SCREEN_PNG
 export const LOADING_SCREEN_PNG = theme.LOADING_SCREEN_PNG
+export const ICON_RADIUS_FACTOR = theme.ICON_RADIUS_FACTOR //.1 icons are square, .5 they are circle

--- a/app/constants/icons.js
+++ b/app/constants/icons.js
@@ -1,0 +1,6 @@
+import * as theme from './iconsRocketChat';
+
+export const PRIVATE_GROUP_ICON = theme.PRIVATE_GROUP_ICON
+export const PUBLIC_GROUP_ICON = theme.PUBLIC_GROUP_ICON
+export const IS_LOADING_SCREEN_PNG = theme.IS_LOADING_SCREEN_PNG
+export const LOADING_SCREEN_PNG = theme.LOADING_SCREEN_PNG

--- a/app/constants/iconsRocketChat.js
+++ b/app/constants/iconsRocketChat.js
@@ -1,4 +1,5 @@
-export const PRIVATE_GROUP_ICON = 'lock'
-export const PUBLIC_GROUP_ICON = 'hashtag'
-export const IS_LOADING_SCREEN_PNG = true
-export const LOADING_SCREEN_PNG = 'launch_screen'
+export const PRIVATE_GROUP_ICON = 'lock';
+export const PUBLIC_GROUP_ICON = 'hashtag';
+export const IS_LOADING_SCREEN_PNG = true;
+export const LOADING_SCREEN_PNG = 'launch_screen';
+export const ICON_RADIUS_FACTOR = .1;

--- a/app/constants/iconsRocketChat.js
+++ b/app/constants/iconsRocketChat.js
@@ -1,0 +1,4 @@
+export const PRIVATE_GROUP_ICON = 'lock'
+export const PUBLIC_GROUP_ICON = 'hashtag'
+export const IS_LOADING_SCREEN_PNG = true
+export const LOADING_SCREEN_PNG = 'launch_screen'

--- a/app/containers/Avatar.js
+++ b/app/containers/Avatar.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { View, ViewPropTypes } from 'react-native';
 import FastImage from 'react-native-fast-image';
+import { ICON_RADIUS_FACTOR } from '../constants/icons';
 
 const Avatar = React.memo(({
 	text, size, baseUrl, borderRadius, style, avatar, type, children, userId, token
@@ -63,7 +64,7 @@ Avatar.defaultProps = {
 	text: '',
 	size: 25,
 	type: 'd',
-	borderRadius: 4
+	borderRadius: 25 * ICON_RADIUS_FACTOR
 };
 
 export default Avatar;

--- a/app/containers/HeaderButton.js
+++ b/app/containers/HeaderButton.js
@@ -4,9 +4,9 @@ import HeaderButtons, { HeaderButton, Item } from 'react-navigation-header-butto
 
 import { CustomIcon } from '../lib/Icons';
 import { isIOS } from '../utils/deviceInfo';
-import { COLOR_PRIMARY, COLOR_WHITE } from '../constants/colors';
+import { COLOR_TITLE_HEADER_BUTTON } from '../constants/colors';
 
-const color = isIOS ? COLOR_PRIMARY : COLOR_WHITE;
+const color = COLOR_TITLE_HEADER_BUTTON
 export const headerIconSize = 23;
 
 const CustomHeaderButton = React.memo(props => (

--- a/app/containers/MessageBox/index.js
+++ b/app/containers/MessageBox/index.js
@@ -31,7 +31,7 @@ import I18n from '../../i18n';
 import ReplyPreview from './ReplyPreview';
 import { CustomIcon } from '../../lib/Icons';
 import debounce from '../../utils/debounce';
-import { COLOR_PRIMARY, COLOR_TEXT_DESCRIPTION } from '../../constants/colors';
+import { COLOR_KEYBOARD_ICONS, COLOR_TEXT_DESCRIPTION } from '../../constants/colors';
 
 const MENTIONS_TRACKING_TYPE_USERS = '@';
 const MENTIONS_TRACKING_TYPE_EMOJIS = ':';
@@ -254,7 +254,7 @@ class MessageBox extends Component {
 				>
 					<CustomIcon
 						size={22}
-						color={COLOR_PRIMARY}
+						color={COLOR_KEYBOARD_ICONS}
 						name='cross'
 					/>
 				</BorderlessButton>
@@ -271,7 +271,7 @@ class MessageBox extends Component {
 				>
 					<CustomIcon
 						size={22}
-						color={COLOR_PRIMARY}
+						color={COLOR_KEYBOARD_ICONS}
 						name='emoji'
 					/>
 				</BorderlessButton>
@@ -286,7 +286,7 @@ class MessageBox extends Component {
 				>
 					<CustomIcon
 						size={22}
-						color={COLOR_PRIMARY}
+						color={COLOR_KEYBOARD_ICONS}
 						name='keyboard'
 					/>
 				</BorderlessButton>
@@ -307,7 +307,7 @@ class MessageBox extends Component {
 					accessibilityLabel={I18n.t('Send message')}
 					accessibilityTraits='button'
 				>
-					<CustomIcon name='send1' size={23} color={COLOR_PRIMARY} />
+					<CustomIcon name='send1' size={23} color={COLOR_KEYBOARD_ICONS} />
 				</BorderlessButton>
 			);
 			return icons;
@@ -321,7 +321,7 @@ class MessageBox extends Component {
 				accessibilityLabel={I18n.t('Send audio message')}
 				accessibilityTraits='button'
 			>
-				<CustomIcon name='mic' size={23} color={COLOR_PRIMARY} />
+				<CustomIcon name='mic' size={23} color={COLOR_KEYBOARD_ICONS} />
 			</BorderlessButton>
 		);
 		icons.push(
@@ -333,7 +333,7 @@ class MessageBox extends Component {
 				accessibilityLabel={I18n.t('Message actions')}
 				accessibilityTraits='button'
 			>
-				<CustomIcon name='plus' size={23} color={COLOR_PRIMARY} />
+				<CustomIcon name='plus' size={23} color={COLOR_KEYBOARD_ICONS} />
 			</BorderlessButton>
 		);
 		return icons;

--- a/app/containers/MessageBox/styles.js
+++ b/app/containers/MessageBox/styles.js
@@ -3,14 +3,14 @@ import { StyleSheet } from 'react-native';
 import { isIOS } from '../../utils/deviceInfo';
 import sharedStyles from '../../views/Styles';
 import {
-	COLOR_BORDER, COLOR_SEPARATOR, COLOR_BACKGROUND_CONTAINER, COLOR_WHITE
+	COLOR_BORDER, COLOR_SEPARATOR, COLOR_BACKGROUND_CONTAINER, COLOR_WHITE, COLOR_TEXT_INPUT_BACKGROUND
 } from '../../constants/colors';
 
 const MENTION_HEIGHT = 50;
 
 export default StyleSheet.create({
 	textBox: {
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_TEXT_INPUT_BACKGROUND,
 		flex: 0,
 		alignItems: 'center',
 		borderTopWidth: StyleSheet.hairlineWidth,
@@ -27,7 +27,7 @@ export default StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		flexGrow: 0,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_TEXT_INPUT_BACKGROUND
 	},
 	textBoxInput: {
 		textAlignVertical: 'center',

--- a/app/containers/RoomTypeIcon.js
+++ b/app/containers/RoomTypeIcon.js
@@ -2,14 +2,15 @@ import React from 'react';
 import { Image, StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 import { CustomIcon } from '../lib/Icons';
-import { COLOR_TEXT_DESCRIPTION } from '../constants/colors';
+import { COLOR_TEXT_DESCRIPTION, COLOR_WHITE } from '../constants/colors';
+import { PUBLIC_GROUP_ICON, PRIVATE_GROUP_ICON} from '../constants/icons';
 
 const styles = StyleSheet.create({
 	style: {
 		marginRight: 7,
 		marginTop: 3,
 		tintColor: COLOR_TEXT_DESCRIPTION,
-		color: COLOR_TEXT_DESCRIPTION
+		backgroundColor: COLOR_WHITE
 	},
 	discussion: {
 		marginRight: 6
@@ -27,9 +28,9 @@ const RoomTypeIcon = React.memo(({ type, size, style }) => {
 	}
 
 	if (type === 'c') {
-		return <Image source={{ uri: 'hashtag' }} style={[styles.style, style, { width: size, height: size }]} />;
+		return <Image source={{ uri: PUBLIC_GROUP_ICON }} style={[styles.style, style, { width: size, height: size }]} />;
 	}
-	return <Image source={{ uri: 'lock' }} style={[styles.style, style, { width: size, height: size }]} />;
+	return <Image source={{ uri: PRIVATE_GROUP_ICON }} style={[styles.style, style, { width: size, height: size }]} />;
 });
 
 RoomTypeIcon.propTypes = {

--- a/app/containers/SearchBox.js
+++ b/app/containers/SearchBox.js
@@ -6,16 +6,17 @@ import I18n from '../i18n';
 import { isIOS } from '../utils/deviceInfo';
 import { CustomIcon } from '../lib/Icons';
 import sharedStyles from '../views/Styles';
+import { COLOR_SEARCHBOX_CONTAINER, COLOR_SEARCHBOX_BACKGROUND, COLOR_SEARCHBOX_TEXT } from '../constants/colors';
 
 const styles = StyleSheet.create({
 	container: {
-		backgroundColor: isIOS ? '#F7F8FA' : '#54585E'
+		backgroundColor: COLOR_SEARCHBOX_CONTAINER
 	},
 	searchBox: {
 		alignItems: 'center',
-		backgroundColor: '#E1E5E8',
+		backgroundColor: COLOR_SEARCHBOX_BACKGROUND,
 		borderRadius: 10,
-		color: '#8E8E93',
+		color: COLOR_SEARCHBOX_TEXT,
 		flexDirection: 'row',
 		fontSize: 17,
 		height: 36,
@@ -24,7 +25,7 @@ const styles = StyleSheet.create({
 		paddingHorizontal: 10
 	},
 	input: {
-		color: '#8E8E93',
+		color: COLOR_SEARCHBOX_TEXT,
 		flex: 1,
 		fontSize: 17,
 		marginLeft: 8,
@@ -37,7 +38,7 @@ const styles = StyleSheet.create({
 const SearchBox = ({ onChangeText, testID }) => (
 	<View style={styles.container}>
 		<View style={styles.searchBox}>
-			<CustomIcon name='magnifier' size={14} color='#8E8E93' />
+			<CustomIcon name='magnifier' size={14} color={COLOR_SEARCHBOX_TEXT} />
 			<TextInput
 				autoCapitalize='none'
 				autoCorrect={false}

--- a/app/containers/TextInput.js
+++ b/app/containers/TextInput.js
@@ -7,7 +7,7 @@ import { BorderlessButton } from 'react-native-gesture-handler';
 
 import sharedStyles from '../views/Styles';
 import {
-	COLOR_DANGER, COLOR_TEXT_DESCRIPTION, COLOR_TEXT, COLOR_BORDER
+	COLOR_DANGER, COLOR_TEXT_DESCRIPTION, COLOR_TEXT, COLOR_BORDER, COLOR_TEXT_INPUT_BACKGROUND
 } from '../constants/colors';
 import { CustomIcon } from '../lib/Icons';
 
@@ -30,7 +30,7 @@ const styles = StyleSheet.create({
 		paddingRight: 14,
 		borderWidth: 1,
 		borderRadius: 2,
-		backgroundColor: 'white',
+		backgroundColor: COLOR_TEXT_INPUT_BACKGROUND,
 		borderColor: COLOR_BORDER
 	},
 	inputIconLeft: {

--- a/app/containers/message/Message.js
+++ b/app/containers/message/Message.js
@@ -27,6 +27,7 @@ import { COLOR_DANGER } from '../../constants/colors';
 import debounce from '../../utils/debounce';
 import DisclosureIndicator from '../DisclosureIndicator';
 import sharedStyles from '../../views/Styles';
+import { ICON_RADIUS_FACTOR } from '../../constants/icons';
 
 const SYSTEM_MESSAGES = [
 	'r',
@@ -244,7 +245,7 @@ export default class Message extends PureComponent {
 					style={small ? styles.avatarSmall : styles.avatar}
 					text={avatar ? '' : author.username}
 					size={small ? 20 : 36}
-					borderRadius={small ? 2 : 4}
+					borderRadius={small ? 20 * ICON_RADIUS_FACTOR: 36 * ICON_RADIUS_FACTOR}
 					avatar={avatar}
 					baseUrl={baseUrl}
 					userId={user.id}

--- a/app/containers/message/Url.js
+++ b/app/containers/message/Url.js
@@ -8,7 +8,7 @@ import isEqual from 'lodash/isEqual';
 import openLink from '../../utils/openLink';
 import sharedStyles from '../../views/Styles';
 import {
-	COLOR_BACKGROUND_CONTAINER, COLOR_BORDER, COLOR_PRIMARY
+	COLOR_BACKGROUND_CONTAINER, COLOR_BORDER, COLOR_PRIMARY, COLOR_LINK_TITLE
 } from '../../constants/colors';
 
 const styles = StyleSheet.create({
@@ -31,7 +31,7 @@ const styles = StyleSheet.create({
 		alignItems: 'flex-start'
 	},
 	title: {
-		color: COLOR_PRIMARY,
+		color: COLOR_LINK_TITLE,
 		fontSize: 16,
 		...sharedStyles.textMedium
 	},

--- a/app/containers/message/styles.js
+++ b/app/containers/message/styles.js
@@ -2,7 +2,11 @@ import { StyleSheet, Platform } from 'react-native';
 
 import sharedStyles from '../../views/Styles';
 import {
-	COLOR_BORDER, COLOR_PRIMARY, COLOR_WHITE, COLOR_BACKGROUND_CONTAINER
+	COLOR_BORDER, COLOR_PRIMARY, COLOR_WHITE, COLOR_BACKGROUND_CONTAINER, COLOR_MENTIONED_USER,
+	COLOR_BACKGROUND_MENTIONED_USER, COLOR_MENTIONED_LOGGED_USER,
+	COLOR_BACKGROUND_MENTIONED_LOGGED_USER, COLOR_MENTIONED_USER_ALL,
+	COLOR_BACKGROUND_MENTIONED_USER_ALL, COLOR_LINK, COLOR_REPLIED_THREAD, COLOR_MESSAGE_THREAD,
+    COLOR_MESSAGE_THREAD_TEXT, COLOR_REACTIONS, COLOR_REACTIONS_COUNT
 } from '../../constants/colors';
 
 const codeFontFamily = Platform.select({
@@ -77,17 +81,18 @@ export default StyleSheet.create({
 		borderRadius: 2,
 		borderWidth: 1,
 		borderColor: COLOR_BORDER,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER,
 		height: 28,
 		minWidth: 46.3
 	},
 	reactedContainer: {
-		borderColor: COLOR_PRIMARY
+		borderColor: COLOR_REACTIONS
 	},
 	reactionCount: {
 		fontSize: 14,
 		marginLeft: 3,
 		marginRight: 8.5,
-		color: COLOR_PRIMARY,
+		color: COLOR_REACTIONS_COUNT,
 		...sharedStyles.textSemibold
 	},
 	reactionEmoji: {
@@ -106,7 +111,7 @@ export default StyleSheet.create({
 		marginLeft: 16
 	},
 	addReaction: {
-		color: COLOR_PRIMARY
+		color: COLOR_REACTIONS
 	},
 	errorButton: {
 		paddingHorizontal: 15,
@@ -123,34 +128,34 @@ export default StyleSheet.create({
 		flexDirection: 'row',
 		alignItems: 'center',
 		justifyContent: 'center',
-		backgroundColor: COLOR_PRIMARY,
+		backgroundColor: COLOR_MESSAGE_THREAD,
 		borderRadius: 2
 	},
 	smallButton: {
 		height: 30
 	},
 	buttonIcon: {
-		color: COLOR_WHITE,
+		color: COLOR_MESSAGE_THREAD_TEXT,
 		marginRight: 6
 	},
 	buttonText: {
-		color: COLOR_WHITE,
+		color: COLOR_MESSAGE_THREAD_TEXT,
 		fontSize: 14,
 		...sharedStyles.textMedium
 	},
 	mention: {
 		...sharedStyles.textMedium,
-		color: '#0072FE',
+		color: COLOR_MENTIONED_USER,
 		padding: 5,
-		backgroundColor: '#E8F2FF'
+		backgroundColor: COLOR_BACKGROUND_MENTIONED_USER
 	},
 	mentionLoggedUser: {
-		color: COLOR_WHITE,
-		backgroundColor: COLOR_PRIMARY
+		color: COLOR_MENTIONED_LOGGED_USER,
+		backgroundColor: COLOR_BACKGROUND_MENTIONED_LOGGED_USER
 	},
 	mentionAll: {
-		color: COLOR_WHITE,
-		backgroundColor: '#FF5B5A'
+		color: COLOR_MENTIONED_USER_ALL,
+		backgroundColor: COLOR_BACKGROUND_MENTIONED_USER_ALL
 	},
 	paragraph: {
 		marginTop: 0,
@@ -200,7 +205,7 @@ export default StyleSheet.create({
 		padding: 4
 	},
 	link: {
-		color: COLOR_PRIMARY,
+		color: COLOR_LINK,
 		...sharedStyles.textRegular
 	},
 	startedDiscussion: {
@@ -226,14 +231,14 @@ export default StyleSheet.create({
 		marginBottom: 12
 	},
 	repliedThreadIcon: {
-		color: COLOR_PRIMARY,
+		color: COLOR_REPLIED_THREAD,
 		marginRight: 10,
 		marginLeft: 16
 	},
 	repliedThreadName: {
 		fontSize: 16,
 		flex: 1,
-		color: COLOR_PRIMARY,
+		color: COLOR_REPLIED_THREAD,
 		...sharedStyles.textRegular
 	}
 });

--- a/app/views/AuthLoadingView.js
+++ b/app/views/AuthLoadingView.js
@@ -1,8 +1,10 @@
 import React from 'react';
-import { StyleSheet, Image } from 'react-native';
+import { StyleSheet, Image, View } from 'react-native';
 
 import StatusBar from '../containers/StatusBar';
 import { isAndroid } from '../utils/deviceInfo';
+import { LOADING_SCREEN_BACKGROUND } from '../constants/colors';
+import { IS_LOADING_SCREEN_PNG, LOADING_SCREEN_PNG} from '../constants/icons';
 
 const styles = StyleSheet.create({
 	image: {
@@ -11,9 +13,18 @@ const styles = StyleSheet.create({
 	}
 });
 
+//FIXME: I'm not sure where this is shown
+const getLaunchScreen = () => {
+    if (IS_LOADING_SCREEN_PNG) {
+        return <Image source={{ uri: LOADING_SCREEN_PNG }} style={styles.image} />
+    } else {
+        return <View style={{ backgroundColor: LOADING_SCREEN_BACKGROUND}} />
+    }
+}
+
 export default React.memo(() => (
 	<React.Fragment>
 		<StatusBar />
-		{isAndroid ? <Image source={{ uri: 'launch_screen' }} style={styles.image} /> : null}
+		{isAndroid ? getLaunchScreen() : null}
 	</React.Fragment>
 ));

--- a/app/views/CreateChannelView.js
+++ b/app/views/CreateChannelView.js
@@ -20,7 +20,9 @@ import { showErrorAlert } from '../utils/info';
 import { isAndroid } from '../utils/deviceInfo';
 import { CustomHeaderButtons, Item } from '../containers/HeaderButton';
 import StatusBar from '../containers/StatusBar';
-import { COLOR_TEXT_DESCRIPTION, COLOR_WHITE } from '../constants/colors';
+import {
+    COLOR_TEXT_DESCRIPTION, COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_BACKGROUND_LIST
+} from '../constants/colors';
 
 const styles = StyleSheet.create({
 	container: {
@@ -29,7 +31,7 @@ const styles = StyleSheet.create({
 	},
 	list: {
 		width: '100%',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	separator: {
 		marginLeft: 60
@@ -43,11 +45,11 @@ const styles = StyleSheet.create({
 		fontSize: 17,
 		...sharedStyles.textRegular,
 		...sharedStyles.textColorNormal,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	swithContainer: {
 		height: 54,
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		alignItems: 'center',
 		justifyContent: 'space-between',
 		flexDirection: 'row',

--- a/app/views/LegalView.js
+++ b/app/views/LegalView.js
@@ -13,7 +13,9 @@ import LoggedView from './View';
 import I18n from '../i18n';
 import DisclosureIndicator from '../containers/DisclosureIndicator';
 import StatusBar from '../containers/StatusBar';
-import { COLOR_SEPARATOR, COLOR_WHITE } from '../constants/colors';
+import {
+    COLOR_SEPARATOR, COLOR_BACKGROUND_LIST, COLOR_BACKGROUND_CONTAINER_PRIMARY
+} from '../constants/colors';
 import openLink from '../utils/openLink';
 
 const styles = StyleSheet.create({
@@ -23,7 +25,7 @@ const styles = StyleSheet.create({
 	},
 	scroll: {
 		marginTop: 35,
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_LIST,
 		borderColor: COLOR_SEPARATOR,
 		borderTopWidth: StyleSheet.hairlineWidth,
 		borderBottomWidth: StyleSheet.hairlineWidth
@@ -37,7 +39,7 @@ const styles = StyleSheet.create({
 	item: {
 		width: '100%',
 		height: 48,
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		paddingLeft: 20,
 		paddingRight: 10,
 		flexDirection: 'row',

--- a/app/views/MessagesView/styles.js
+++ b/app/views/MessagesView/styles.js
@@ -1,18 +1,18 @@
 import { StyleSheet } from 'react-native';
 
 import sharedStyles from '../Styles';
-import { COLOR_WHITE } from '../../constants/colors';
+import { COLOR_BACKGROUND_LIST } from '../../constants/colors';
 
 export default StyleSheet.create({
 	list: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	listEmptyContainer: {
 		flex: 1,
 		alignItems: 'center',
 		justifyContent: 'center',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	noDataFound: {
 		fontSize: 14,

--- a/app/views/NewMessageView.js
+++ b/app/views/NewMessageView.js
@@ -20,12 +20,12 @@ import SearchBox from '../containers/SearchBox';
 import { CustomIcon } from '../lib/Icons';
 import { CloseModalButton } from '../containers/HeaderButton';
 import StatusBar from '../containers/StatusBar';
-import { COLOR_PRIMARY, COLOR_WHITE } from '../constants/colors';
+import { COLOR_PRIMARY, COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_SAFE_AREA_BACKGROUND } from '../constants/colors';
 
 const styles = StyleSheet.create({
 	safeAreaView: {
 		flex: 1,
-		backgroundColor: isIOS ? '#F7F8FA' : '#E1E5E8'
+		backgroundColor: COLOR_SAFE_AREA_BACKGROUND
 	},
 	separator: {
 		marginLeft: 60
@@ -35,7 +35,7 @@ const styles = StyleSheet.create({
 	},
 	createChannelContainer: {
 		height: 47,
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		flexDirection: 'row',
 		alignItems: 'center'
 	},

--- a/app/views/OnboardingView/styles.js
+++ b/app/views/OnboardingView/styles.js
@@ -2,7 +2,9 @@ import { StyleSheet } from 'react-native';
 
 import { verticalScale, moderateScale } from '../../utils/scaling';
 import sharedStyles from '../Styles';
-import { COLOR_PRIMARY, COLOR_BORDER, COLOR_WHITE } from '../../constants/colors';
+import {
+    COLOR_PRIMARY, COLOR_BORDER, COLOR_BACKGROUND_CONTAINER_PRIMARY
+} from '../../constants/colors';
 
 const colors = {
 	backgroundPrimary: COLOR_PRIMARY,
@@ -19,7 +21,7 @@ export default StyleSheet.create({
 	container: {
 		flex: 1,
 		flexDirection: 'column',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	onboarding: {
 		alignSelf: 'center',

--- a/app/views/ProfileView/index.js
+++ b/app/views/ProfileView/index.js
@@ -27,6 +27,7 @@ import { CustomIcon } from '../../lib/Icons';
 import { DrawerButton } from '../../containers/HeaderButton';
 import StatusBar from '../../containers/StatusBar';
 import { COLOR_TEXT } from '../../constants/colors';
+import { ICON_RADIUS_FACTOR } from '../../constants/icons';
 
 @connect(state => ({
 	user: {
@@ -286,17 +287,18 @@ export default class ProfileView extends LoggedView {
 		return (
 			<View style={styles.avatarButtons}>
 				{this.renderAvatarButton({
-					child: <Avatar text={`@${ user.username }`} size={50} baseUrl={baseUrl} userId={user.id} token={user.token} />,
+					child: <Avatar text={`@${ user.username }`} size={50} baseUrl={baseUrl}
+					               userId={user.id} token={user.token} borderRadius={50 * ICON_RADIUS_FACTOR}/>,
 					onPress: () => this.resetAvatar(),
 					key: 'profile-view-reset-avatar'
 				})}
 				{this.renderAvatarButton({
-					child: <CustomIcon name='upload' size={30} color={COLOR_TEXT} />,
+					child: <CustomIcon name='upload' size={30} color={COLOR_TEXT} borderRadius={30 * ICON_RADIUS_FACTOR}/>,
 					onPress: () => this.pickImage(),
 					key: 'profile-view-upload-avatar'
 				})}
 				{this.renderAvatarButton({
-					child: <CustomIcon name='permalink' size={30} color={COLOR_TEXT} />,
+					child: <CustomIcon name='permalink' size={30} color={COLOR_TEXT} borderRadius={30 * ICON_RADIUS_FACTOR}/>,
 					onPress: () => this.setAvatar({ url: avatarUrl, data: avatarUrl, service: 'url' }),
 					disabled: !avatarUrl,
 					key: 'profile-view-avatar-url-button'
@@ -402,6 +404,7 @@ export default class ProfileView extends LoggedView {
 								baseUrl={baseUrl}
 								userId={user.id}
 								token={user.token}
+								borderRadius={100 * ICON_RADIUS_FACTOR}
 							/>
 						</View>
 						<RCTextInput

--- a/app/views/ProfileView/styles.js
+++ b/app/views/ProfileView/styles.js
@@ -1,4 +1,8 @@
 import { StyleSheet, Platform } from 'react-native';
+import {
+	COLOR_AVATAR_BUTTON, COLOR_DIALOG_INPUT
+} from '../../constants/colors';
+import { ICON_RADIUS_FACTOR } from '../../constants/icons';
 
 export default StyleSheet.create({
 	avatarContainer: {
@@ -12,22 +16,23 @@ export default StyleSheet.create({
 		justifyContent: 'flex-start'
 	},
 	avatarButton: {
-		backgroundColor: '#e1e5e8',
+		backgroundColor: COLOR_AVATAR_BUTTON,
 		width: 50,
 		height: 50,
 		alignItems: 'center',
 		justifyContent: 'center',
 		marginRight: 15,
 		marginBottom: 15,
-		borderRadius: 2
+		borderRadius: 50 * ICON_RADIUS_FACTOR
 	},
 	dialogInput: Platform.select({
 		ios: {},
 		android: {
 			borderRadius: 4,
-			borderColor: 'rgba(0,0,0,.15)',
+			borderColor: COLOR_DIALOG_INPUT,
 			borderWidth: 2,
 			paddingHorizontal: 10
 		}
 	})
 });
+

--- a/app/views/RoomActionsView/styles.js
+++ b/app/views/RoomActionsView/styles.js
@@ -1,6 +1,7 @@
 import { StyleSheet } from 'react-native';
 import {
-	COLOR_SEPARATOR, COLOR_BORDER, COLOR_DANGER, COLOR_WHITE
+	COLOR_SEPARATOR, COLOR_BORDER, COLOR_DANGER, COLOR_BACKGROUND_CONTAINER_PRIMARY,
+	COLOR_BORDER_SECONDARY
 } from '../../constants/colors';
 
 import sharedStyles from '../Styles';
@@ -11,10 +12,10 @@ export default StyleSheet.create({
 	},
 	container: {
 		flex: 1,
-		backgroundColor: '#F6F7F9'
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	sectionItem: {
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		paddingVertical: 16,
 		flexDirection: 'row',
 		alignItems: 'center'
@@ -44,7 +45,7 @@ export default StyleSheet.create({
 	},
 	sectionSeparator: {
 		height: 10,
-		backgroundColor: '#F6F7F9'
+		backgroundColor: COLOR_BORDER_SECONDARY
 	},
 	sectionSeparatorBorder: {
 		borderColor: COLOR_BORDER,

--- a/app/views/RoomInfoEditView/styles.js
+++ b/app/views/RoomInfoEditView/styles.js
@@ -1,16 +1,19 @@
 import { StyleSheet } from 'react-native';
 
-import { COLOR_DANGER, COLOR_SEPARATOR } from '../../constants/colors';
+import {
+    COLOR_DANGER, COLOR_SEPARATOR, COLOR_BORDER, COLOR_BUTTON_DISABLED
+ } from '../../constants/colors';
+
 import sharedStyles from '../Styles';
 
 export default StyleSheet.create({
 	buttonInverted: {
-		borderColor: 'rgba(0,0,0,.15)',
+		borderColor: COLOR_BORDER,
 		borderWidth: 2,
 		borderRadius: 2
 	},
 	buttonContainerDisabled: {
-		backgroundColor: 'rgba(65, 72, 82, 0.7)'
+		backgroundColor: COLOR_BUTTON_DISABLED
 	},
 	buttonDanger: {
 		borderColor: COLOR_DANGER,

--- a/app/views/RoomInfoView/styles.js
+++ b/app/views/RoomInfoView/styles.js
@@ -1,17 +1,19 @@
 import { StyleSheet } from 'react-native';
 
 import sharedStyles from '../Styles';
-import { COLOR_BACKGROUND_CONTAINER, COLOR_WHITE } from '../../constants/colors';
+import {
+    COLOR_BACKGROUND_CONTAINER, COLOR_BACKGROUND_CONTAINER_PRIMARY
+} from '../../constants/colors';
 
 export default StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	scroll: {
 		flex: 1,
 		flexDirection: 'column',
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		padding: 10
 	},
 	item: {

--- a/app/views/RoomMembersView/styles.js
+++ b/app/views/RoomMembersView/styles.js
@@ -1,10 +1,10 @@
 import { StyleSheet } from 'react-native';
-import { COLOR_SEPARATOR, COLOR_WHITE } from '../../constants/colors';
+import { COLOR_SEPARATOR, COLOR_BACKGROUND_CONTAINER_PRIMARY } from '../../constants/colors';
 
 export default StyleSheet.create({
 	list: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	item: {
 		flexDirection: 'row',

--- a/app/views/RoomView/Header/Header.js
+++ b/app/views/RoomView/Header/Header.js
@@ -10,7 +10,7 @@ import I18n from '../../../i18n';
 import sharedStyles from '../../Styles';
 import { isIOS, isAndroid } from '../../../utils/deviceInfo';
 import Icon from './Icon';
-import { COLOR_TEXT_DESCRIPTION, HEADER_TITLE, COLOR_WHITE } from '../../../constants/colors';
+import { COLOR_TYPING, HEADER_TITLE, COLOR_WHITE } from '../../../constants/colors';
 
 const TITLE_SIZE = 16;
 const styles = StyleSheet.create({
@@ -34,7 +34,7 @@ const styles = StyleSheet.create({
 	},
 	typing: {
 		...sharedStyles.textRegular,
-		color: isIOS ? COLOR_TEXT_DESCRIPTION : COLOR_WHITE,
+		color: COLOR_TYPING,
 		fontSize: 12,
 		flex: 4
 	},

--- a/app/views/RoomView/Header/Icon.js
+++ b/app/views/RoomView/Header/Icon.js
@@ -2,7 +2,9 @@ import React from 'react';
 import { StyleSheet } from 'react-native';
 import PropTypes from 'prop-types';
 
-import { STATUS_COLORS, COLOR_TEXT_DESCRIPTION, COLOR_WHITE } from '../../../constants/colors';
+import {
+    STATUS_COLORS, COLOR_TEXT_DESCRIPTION, COLOR_WHITE, COLOR_TEXT_HEADER
+} from '../../../constants/colors';
 import { CustomIcon } from '../../../lib/Icons';
 import Status from '../../../containers/Status/Status';
 import { isIOS } from '../../../utils/deviceInfo';
@@ -14,7 +16,7 @@ const styles = StyleSheet.create({
 		width: ICON_SIZE,
 		height: ICON_SIZE,
 		marginRight: 8,
-		color: isIOS ? COLOR_TEXT_DESCRIPTION : COLOR_WHITE
+		color: COLOR_TEXT_HEADER
 	},
 	status: {
 		marginLeft: 4,

--- a/app/views/RoomView/styles.js
+++ b/app/views/RoomView/styles.js
@@ -1,7 +1,7 @@
 import { StyleSheet } from 'react-native';
 
 import {
-	COLOR_SEPARATOR, COLOR_PRIMARY, COLOR_WHITE, COLOR_TEXT_DESCRIPTION
+	COLOR_SEPARATOR, COLOR_PRIMARY, COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_TEXT_DESCRIPTION, COLOR_WHITE
 } from '../../constants/colors';
 import { isIOS } from '../../utils/deviceInfo';
 import sharedStyles from '../Styles';
@@ -9,7 +9,7 @@ import sharedStyles from '../Styles';
 export default StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	safeAreaView: {
 		flex: 1
@@ -37,7 +37,7 @@ export default StyleSheet.create({
 	reactionPickerContainer: {
 		// width: width - 20,
 		// height: width - 20,
-		backgroundColor: '#F7F7F7',
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		borderRadius: 4,
 		flexDirection: 'column'
 	},

--- a/app/views/RoomsListView/ListHeader/Sort.js
+++ b/app/views/RoomsListView/ListHeader/Sort.js
@@ -20,7 +20,7 @@ const Sort = React.memo(({ searchLength, sortBy, toggleSort }) => {
 		>
 			<View style={styles.sortItemContainer}>
 				<Text style={styles.sortToggleText}>{I18n.t('Sorting_by', { key: I18n.t(sortBy === 'alphabetical' ? 'name' : 'activity') })}</Text>
-				<CustomIcon style={styles.sortIcon} size={22} name='sort1' />
+				<CustomIcon style={styles.sortIconHeader} size={22} name='sort1' />
 			</View>
 		</Touch>
 	);

--- a/app/views/RoomsListView/styles.js
+++ b/app/views/RoomsListView/styles.js
@@ -1,7 +1,11 @@
 import { StyleSheet } from 'react-native';
 import { isIOS } from '../../utils/deviceInfo';
 import {
-	COLOR_SEPARATOR, COLOR_TEXT, COLOR_PRIMARY, COLOR_WHITE
+	COLOR_SEPARATOR, COLOR_TEXT, COLOR_PRIMARY, COLOR_TEXT_DESCRIPTION,
+	COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_BACKGROUND_LIST, COLOR_DROPDOWN_CONTAINER_HEADER,
+	COLOR_WHITE, HEADER_BACK, COLOR_GROUP_TITLE_CONTAINER, COLOR_GROUP_TITLE, COLOR_GROUP_SORT_ICON,
+	COLOR_TEXT_DROPDOWN_CONTAINER, COLOR_SEARCHBOX_BACKGROUND, COLOR_ROOMS_ACTION_BUTTON,
+	COLOR_GROUP_SORT_ICON_HEADER, COLOR_TEXT_HEADER
 } from '../../constants/colors';
 
 import sharedStyles from '../Styles';
@@ -9,16 +13,16 @@ import sharedStyles from '../Styles';
 export default StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: isIOS ? COLOR_WHITE : '#E1E5E8'
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	list: {
 		width: '100%',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	actionButtonIcon: {
-		fontSize: 20,
+		fontSize: 40,
 		height: 22,
-		color: 'white'
+		color: COLOR_ROOMS_ACTION_BUTTON
 	},
 	loading: {
 		flex: 1
@@ -28,7 +32,7 @@ export default StyleSheet.create({
 		borderBottomWidth: StyleSheet.hairlineWidth,
 		borderColor: COLOR_SEPARATOR,
 		alignItems: 'center',
-		backgroundColor: isIOS ? COLOR_WHITE : '#54585E',
+		backgroundColor: COLOR_DROPDOWN_CONTAINER_HEADER,
 		flexDirection: 'row'
 	},
 	sortToggleContainerClose: {
@@ -40,11 +44,11 @@ export default StyleSheet.create({
 		fontSize: 15,
 		flex: 1,
 		marginLeft: 15,
-		...sharedStyles.textColorDescription,
+		color: COLOR_TEXT_DROPDOWN_CONTAINER,
 		...sharedStyles.textRegular
 	},
 	dropdownContainer: {
-		backgroundColor: COLOR_WHITE,
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		width: '100%',
 		position: 'absolute',
 		top: 0
@@ -77,16 +81,22 @@ export default StyleSheet.create({
 		width: 22,
 		height: 22,
 		marginHorizontal: 15,
-		...sharedStyles.textColorDescription
+		backgroundColor: COLOR_GROUP_SORT_ICON
 	},
+    sortIconHeader: {
+        width: 22,
+        height: 22,
+        marginHorizontal: 15,
+        color: COLOR_GROUP_SORT_ICON_HEADER
+    },
 	groupTitleContainer: {
 		paddingHorizontal: 15,
 		paddingTop: 17,
 		paddingBottom: 10,
-		backgroundColor: isIOS ? COLOR_WHITE : '#9ea2a8'
+		backgroundColor: COLOR_GROUP_TITLE_CONTAINER
 	},
 	groupTitle: {
-		color: isIOS ? COLOR_TEXT : '#54585E',
+		color: COLOR_GROUP_TITLE,
 		fontSize: isIOS ? 22 : 15,
 		letterSpacing: 0.27,
 		flex: 1,
@@ -99,11 +109,11 @@ export default StyleSheet.create({
 	serverHeaderText: {
 		fontSize: 15,
 		marginLeft: 15,
-		...sharedStyles.textColorDescription,
+		color: COLOR_TEXT_HEADER,
 		...sharedStyles.textRegular
 	},
 	serverHeaderAdd: {
-		color: isIOS ? COLOR_PRIMARY : COLOR_WHITE,
+		color: HEADER_BACK,
 		fontSize: 15,
 		marginRight: 15,
 		paddingVertical: 10,

--- a/app/views/SearchMessagesView/styles.js
+++ b/app/views/SearchMessagesView/styles.js
@@ -1,12 +1,14 @@
 import { StyleSheet } from 'react-native';
-import { COLOR_SEPARATOR, COLOR_WHITE } from '../../constants/colors';
+import {
+    COLOR_SEPARATOR, COLOR_BACKGROUND_LIST, COLOR_BACKGROUND_CONTAINER_PRIMARY
+} from '../../constants/colors';
 
 import sharedStyles from '../Styles';
 
 export default StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	searchContainer: {
 		padding: 20,
@@ -14,7 +16,7 @@ export default StyleSheet.create({
 	},
 	list: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	divider: {
 		width: '100%',
@@ -26,7 +28,7 @@ export default StyleSheet.create({
 		flex: 1,
 		alignItems: 'center',
 		justifyContent: 'flex-start',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	noDataFound: {
 		fontSize: 14,

--- a/app/views/SidebarView/styles.js
+++ b/app/views/SidebarView/styles.js
@@ -1,19 +1,20 @@
 import { StyleSheet } from 'react-native';
-import { COLOR_SEPARATOR, COLOR_WHITE } from '../../constants/colors';
+import { COLOR_SEPARATOR, COLOR_BACKGROUND_CONTAINER_PRIMARY,
+         COLOR_ITEM_CURRENT } from '../../constants/colors';
 
 import sharedStyles from '../Styles';
 
 export default StyleSheet.create({
 	container: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	item: {
 		flexDirection: 'row',
 		alignItems: 'center'
 	},
 	itemCurrent: {
-		backgroundColor: '#E1E5E8'
+		backgroundColor: COLOR_ITEM_CURRENT
 	},
 	itemLeft: {
 		marginHorizontal: 10,

--- a/app/views/Styles.js
+++ b/app/views/Styles.js
@@ -1,12 +1,14 @@
 import { StyleSheet, Platform } from 'react-native';
 
 import {
-	COLOR_DANGER, COLOR_BUTTON_PRIMARY, COLOR_SEPARATOR, COLOR_TEXT, COLOR_TEXT_DESCRIPTION, COLOR_TITLE
+	COLOR_DANGER, COLOR_BUTTON_PRIMARY, COLOR_SEPARATOR, COLOR_TEXT, COLOR_TEXT_DESCRIPTION,
+	COLOR_TITLE, COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_BUTTON_SECONDARY, COLOR_BORDER_SECONDARY,
+	COLOR_LOADING
 } from '../constants/colors';
 
 export default StyleSheet.create({
 	container: {
-		backgroundColor: 'white',
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY,
 		flex: 1
 	},
 	containerScrollView: {
@@ -18,7 +20,7 @@ export default StyleSheet.create({
 	},
 	buttonContainer: {
 		paddingVertical: 15,
-		backgroundColor: '#414852',
+		backgroundColor: COLOR_BUTTON_SECONDARY,
 		marginBottom: 20,
 		borderRadius: 2
 	},
@@ -28,12 +30,12 @@ export default StyleSheet.create({
 	},
 	button: {
 		textAlign: 'center',
-		color: 'white',
+		color: COLOR_BORDER_SECONDARY,
 		fontWeight: '700'
 	},
 	button_inverted: {
 		textAlign: 'center',
-		color: '#414852',
+		color: COLOR_BUTTON_SECONDARY,
 		fontWeight: '700',
 		flexGrow: 1
 	},
@@ -45,7 +47,7 @@ export default StyleSheet.create({
 	loading: {
 		flex: 1,
 		position: 'absolute',
-		backgroundColor: 'rgba(255,255,255,.2)',
+		backgroundColor: COLOR_LOADING,
 		left: 0,
 		top: 0
 	},
@@ -54,7 +56,7 @@ export default StyleSheet.create({
 		bottom: -3,
 		right: -3,
 		borderWidth: 3,
-		borderColor: '#fff'
+		borderColor: COLOR_BORDER_SECONDARY
 	},
 	link: {
 		fontWeight: 'bold',

--- a/app/views/ThreadMessagesView/styles.js
+++ b/app/views/ThreadMessagesView/styles.js
@@ -1,18 +1,20 @@
 import { StyleSheet } from 'react-native';
 
 import sharedStyles from '../Styles';
-import { COLOR_WHITE, COLOR_SEPARATOR } from '../../constants/colors';
+import {
+    COLOR_BACKGROUND_CONTAINER_PRIMARY, COLOR_BACKGROUND_LIST, COLOR_SEPARATOR
+} from '../../constants/colors';
 
 export default StyleSheet.create({
 	list: {
 		flex: 1,
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_CONTAINER_PRIMARY
 	},
 	listEmptyContainer: {
 		flex: 1,
 		alignItems: 'center',
 		justifyContent: 'center',
-		backgroundColor: COLOR_WHITE
+		backgroundColor: COLOR_BACKGROUND_LIST
 	},
 	noDataFound: {
 		fontSize: 14,


### PR DESCRIPTION
<!-- INSTRUCTION: Keep the line below to notify all core developers about this new PR -->
@RocketChat/ReactNative

<!-- INSTRUCTION: Inform the issue number that this PR closes, or remove the line below -->
Closes #ISSUE_NUMBER

https://github.com/WideChat/Rocket.Chat.Android/issues/517

<!-- INSTRUCTION: Tell us more about your PR with screen shots if you can -->

Adds generic branding to RocketChat client.  The most important changes reside in app/constants/colors.js, app/constants/colorsRocketChat.js, app/constants/icons.js and  app/constants/iconsRocketChat.js.  

When someone wishes to add a new color scheme they must copy colorsRocketChat.js and rename it colors<projectName>.js and define the colors there.  The only other thing to be done is including your new color file in colors.js.  There are similar steps for icons.  All other changes were taking out of hardcoded colors and making them instead color or icon variables.  The work here covers whats necessary to make the style changes for widechat, other projects may need to expand upon it.

The app should look and function just like before so screenshots don't seem necessary here.
